### PR TITLE
Fix missing Elasticsearch index

### DIFF
--- a/config/5-fluentd.yaml
+++ b/config/5-fluentd.yaml
@@ -65,6 +65,14 @@ spec:
             value: "http"
           - name: FLUENTD_SYSTEMD_CONF
             value: disable
+          - name: FLUENT_ELASTICSEARCH_LOGSTASH_FORMAT
+            value: "true"
+          - name: FLUENT_ELASTICSEARCH_LOGSTASH_INDEX_NAME
+            value: "logstash"
+          - name: FLUENT_CONTAINER_TAIL_EXCLUDE_PATH
+            value: /var/log/containers/fluentd-*
+          - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+            value: /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
         resources:
           limits:
             memory: 512Mi


### PR DESCRIPTION
After applying all the described YAML files to create the needed resources it was no longer possible to detect the elasticsearch index in the Kibana dashboard. After troubleshooting and searching the web the following post: 'https://www.digitalocean.com/community/questions/logging-with-efk-couldn-t-find-any-elasticsearch-kubernetes' gave answer to the solution. This issue resulted when running the stack on a real Azure K8s cluster instead of the single-node Docker Desktop K8s cluster.