### PR TITLE
Feature/externalize kibana service

### DIFF
--- a/config/4-kibana.yaml
+++ b/config/4-kibana.yaml
@@ -6,9 +6,10 @@ metadata:
   labels:
     app: kibana
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
-  - port: 5601
+  - protocol: TCP
+    port: 80
     targetPort: 5601
   selector:
     app: kibana

--- a/config/4-kibana.yaml
+++ b/config/4-kibana.yaml
@@ -6,8 +6,10 @@ metadata:
   labels:
     app: kibana
 spec:
+  type: NodePort
   ports:
   - port: 5601
+    targetPort: 5601
   selector:
     app: kibana
 ---


### PR DESCRIPTION
This will make the Kibana service available outside the cluster via External ClusterIP and port 80.